### PR TITLE
Add a project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.o
+kernel.elf

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,29 @@
 KERNBIN := kernel.elf
-OBJ := start.o \
-	kmain.o
+LDSCRIPT := linker.ld
 
-CFLAGS := -O0 -ffreestanding -nostdlib -Wall -Wextra
+OBJ := start.o \
+       kmain.o
+
+CFLAGS := -O0 -ffreestanding -nostdlib -Wall -Wextra -g
 
 all: $(KERNBIN)
-
-LDSCRIPT := linker.ld
 
 $(KERNBIN): $(OBJ)
 	$(LD) -T $(LDSCRIPT) -o $@ $^
 
-.PHONY: clean
+.PHONY: clean qemu qemu-gdb
 clean:
 	@rm -f $(OBJ) $(KERNBIN)
+
+QEMU := $(shell which qemu-system-aarch64)
+QEMUOPTS := -machine raspi3\
+	    -display none\
+	    -serial null\
+	    -serial stdio\
+	    -kernel $(KERNBIN)
+
+qemu: all
+	$(QEMU) $(QEMUOPTS)
+
+qemu-gdb: all
+	$(QEMU) $(QEMUOPTS) -s -S

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+KERNBIN := kernel.elf
+OBJ := start.o \
+	kmain.o
+
+CFLAGS := -O0 -ffreestanding -nostdlib -Wall -Wextra
+
+all: $(KERNBIN)
+
+LDSCRIPT := linker.ld
+
+$(KERNBIN): $(OBJ)
+	$(LD) -T $(LDSCRIPT) -o $@ $^
+
+.PHONY: clean
+clean:
+	@rm -f $(OBJ) $(KERNBIN)

--- a/kmain.c
+++ b/kmain.c
@@ -1,0 +1,6 @@
+int kmain(void)
+{
+	for (;;) {
+		; /* infinite loop :-) */
+	}
+}

--- a/linker.ld
+++ b/linker.ld
@@ -1,0 +1,23 @@
+/* This linker script was taken from: https://github.com/bztsrc/raspi3-tutorial
+ * lesson "02_multicorec" -- thank you!
+ */
+
+SECTIONS
+{
+    . = 0x80000;
+    .text : { KEEP(*(.text.boot)) *(.text .text.* .gnu.linkonce.t*) }
+    .rodata : { *(.rodata .rodata.* .gnu.linkonce.r*) }
+    PROVIDE(_data = .);
+    .data : { *(.data .data.* .gnu.linkonce.d*) }
+    .bss (NOLOAD) : {
+        . = ALIGN(16);
+        __bss_start = .;
+        *(.bss .bss.*)
+        *(COMMON)
+        __bss_end = .;
+    }
+    _end = .;
+
+   /DISCARD/ : { *(.comment) *(.gnu*) *(.note*) *(.eh_frame*) }
+}
+__bss_size = (__bss_end - __bss_start)>>3;

--- a/start.S
+++ b/start.S
@@ -1,0 +1,62 @@
+/* With minor changes, this start code was taken from:
+ * https://github.com/bztsrc/raspi3-tutorial
+ *
+ * Thank you!
+ */
+
+.section ".text.boot"
+
+.global _start
+
+_start:
+	/* Read Multiprocessor Affinity Register with special MRS instruction
+	 * used to access system registers to identify what core we're running on.
+	 * Reference: https://developer.arm.com/docs/ddi0500/g/system-control/aarch64-register-descriptions/multiprocessor-affinity-register
+	 */
+	mrs     x1, mpidr_el1
+
+	/* Cortex-A53 is equipped with 4 cores (all of which are running), so
+	 * we will want to park the other 3 while the primary core (core 0)
+	 * performs set-up.
+	 *
+	 * This is a 64-bit register where the core identifier is in the last
+	 * 2 bits (4 cores, only 2 bits needed to represent IDs up to 4). Mask
+	 * them off. If the identifier is 0, then this is the primary core with
+	 * which we'll perform set-up with.
+	 */
+	and     x1, x1, #0x3
+	cbz     x1, begin_setup
+wait_here:
+	/* Otherwise, we'll park the core here and tell it to wait for an event.
+	 * (presumably from us)
+	 * Reference: https://developer.arm.com/docs/den0024/latest/the-a64-instruction-set/system-control-and-other-instructions/hint-instructions
+	 */
+	wfe
+	b 	wait_here
+
+begin_setup:
+	/* Move the stack to grow down from where our code begins. */
+	ldr     x1, =_start
+	mov     sp, x1
+
+	/* Load the bss (refer to linker script to see where these are) */
+	ldr     x1, =__bss_start
+	ldr     w2, =__bss_size
+
+clear_bss:
+	/* Global variables live in the bss section, and therefore we must zero it
+	 * out.
+	 *
+	 * We've stored the size of the bss in w2, so once this hits zero, we
+	 * have cleared the entire section.
+	 */
+	cbz     w2, enter_kernel
+	str     xzr, [x1], #8
+	sub     w2, w2, #1
+	cbnz    w2, clear_bss
+
+enter_kernel:
+	/* Enter C code... */
+	bl      kmain
+	/* ...we should never return here. */
+	b	wait_here


### PR DESCRIPTION
This PR provides a basic makefile with a default target and a `clean` (`make clean`) target.

I've been building the project in a chroot like this:

```
$ schroot -c chroot:eoan-arm64 -- make
```

The Makefile doesn't modify the `CC` environment variable, so as long as your `CC` and `LD` environment variables are pointing at the right binaries it should work... I think.

I've been running it like this:

```
$ qemu-system-aarch64 -machine raspi3 -serial null -serial stdio -kernel kernel.elf
```